### PR TITLE
Ignore msw for browser bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
     "stylelint-order": "^4.1.0",
     "wait-on": "^5.3.0"
   },
+  "browser": {
+    "./.msw": false
+  },
   "babel": {
     "presets": [
       "next/babel"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -10,6 +10,10 @@ import Main from "../components/main";
 import Page from "../components/page";
 
 if (process.env.API_MOCKING === "enabled") {
+  /**
+   * This require will only be loaded server-side when api mocking is enabled, due
+   * to a bug in next.js bundling: https://github.com/ismay/superwolff/issues/4
+   */
   require("../.msw");
 }
 


### PR DESCRIPTION
Temporary workaround that eliminates msw from browser bundle.

See #4